### PR TITLE
hi¡ daft punk

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,2 @@
 github: ryanve
-patreon: ryanve
-open_collective: s9a
 ko_fi: ryanve


### PR DESCRIPTION
keep only [github](https://github.com/sponsors/ryanve) and [ko-fi](https://ko-fi.com/ryanve) 
because
opencollective dissolved
patreon dissed

